### PR TITLE
Limit the number of screenshots

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -1,6 +1,6 @@
 """API methods."""
 
-from datetime import timedelta
+from datetime import timedelta, datetime
 from typing import Annotated
 
 from fastapi import Body, Depends, FastAPI, HTTPException
@@ -11,8 +11,6 @@ from sqlmodel import Session, select
 from app.auth import auth_handler
 from app.auth import crypto
 from app import model
-
-import datetime
 
 
 app_obj = FastAPI()
@@ -160,7 +158,7 @@ async def add_screenshots(
     screenshot_db = model.Screenshot.model_validate(
         screenshot, update={
             "owner_id": current_user_id.id,
-            "created_on": datetime.datetime.now()
+            "created_on": datetime.now()
             })
     screenshot_db.external_id = crypto.generate_random_base64_string(32)
     session.add(screenshot_db)

--- a/app/model.py
+++ b/app/model.py
@@ -2,11 +2,11 @@
 """
 
 import os
+from datetime import datetime
 from typing import Optional, Union
 
 from pydantic import BaseModel, EmailStr
 from sqlmodel import Field, Session, SQLModel, create_engine
-from datetime import datetime
 
 connect_args = {"check_same_thread": False}
 engine = create_engine(

--- a/app/model.py
+++ b/app/model.py
@@ -6,6 +6,7 @@ from typing import Optional, Union
 
 from pydantic import BaseModel, EmailStr
 from sqlmodel import Field, Session, SQLModel, create_engine
+from datetime import datetime
 
 connect_args = {"check_same_thread": False}
 engine = create_engine(
@@ -59,6 +60,7 @@ class ScreenshotCreate(SQLModel):
 class ScreenshotBase(ScreenshotCreate):
     owner_id: int | None = Field(default=None, foreign_key="user.id")
     external_id: str = Field(default = None)
+    created_on: datetime
     #owner: User | None = Relationship(back_populates="screenshots")
 
 class Screenshot(ScreenshotBase, table=True):


### PR DESCRIPTION
Right now, if you have 1000 screenshots in the database, the GET method will load all of them. This change allows us to limit the number. We set 3 by default, but the user can change this to any number.